### PR TITLE
InternalizeExcludes are patterns

### DIFF
--- a/ILRepack.Lib.MSBuild.Task/ILRepack.cs
+++ b/ILRepack.Lib.MSBuild.Task/ILRepack.cs
@@ -306,14 +306,10 @@ namespace ILRepack.Lib.MSBuild.Task
                         internalizeExclude[i] = InternalizeExclude[i].ItemSpec;
                         if (string.IsNullOrEmpty(internalizeExclude[i]))
                         {
-                            throw new Exception($"Invalid assembly internalize exclude path on item index {i}");
-                        }
-                        if (!File.Exists(assemblies[i]) && !File.Exists(BuildPath(assemblies[i])))
-                        {
-                            throw new Exception($"Unable to resolve assembly '{assemblies[i]}'");
+                            throw new Exception($"Invalid internalize exclude pattern at item index {i}. Pattern cannot be blank.");
                         }
                         Log.LogMessage(MessageImportance.High,
-                            "Excluding assembly '{0}' from being internalized", internalizeExclude[i]);
+                            "Excluding namespaces/types matching pattern '{0}' from being internalized", internalizeExclude[i]);
                     }
 
                     // Create a temporary file with a list of assemblies that should not be internalized.

--- a/ILRepack.Lib.MSBuild.Task/Properties/AssemblyInfo.cs
+++ b/ILRepack.Lib.MSBuild.Task/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.0.15.4")]
-[assembly: AssemblyFileVersion("2.0.15.4")]
+[assembly: AssemblyVersion("2.0.16.0")]
+[assembly: AssemblyFileVersion("2.0.16.0")]

--- a/ILRepack.Lib.MSBuild.Task/Properties/AssemblyInfo.cs
+++ b/ILRepack.Lib.MSBuild.Task/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.0.16.0")]
-[assembly: AssemblyFileVersion("2.0.16.0")]
+[assembly: AssemblyVersion("2.0.15.5")]
+[assembly: AssemblyFileVersion("2.0.15.5")]

--- a/ILRepack.Lib.MSBuild.Task/build/ILRepack.Lib.MSBuild.Task.nuspec
+++ b/ILRepack.Lib.MSBuild.Task/build/ILRepack.Lib.MSBuild.Task.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>ILRepack.Lib.MSBuild.Task</id>
-    <version>2.0.15.4</version>
+    <version>2.0.16.0</version>
     <title>ILRepack.Lib.MSBuild.Task</title>
     <authors>RBSoft</authors>
     <owners>rbsoft</owners>

--- a/ILRepack.Lib.MSBuild.Task/build/ILRepack.Lib.MSBuild.Task.nuspec
+++ b/ILRepack.Lib.MSBuild.Task/build/ILRepack.Lib.MSBuild.Task.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>ILRepack.Lib.MSBuild.Task</id>
-    <version>2.0.16.0</version>
+    <version>2.0.15.5</version>
     <title>ILRepack.Lib.MSBuild.Task</title>
     <authors>RBSoft</authors>
     <owners>rbsoft</owners>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
-version: 2.0.15.{build}
+version: 2.0.16.{build}
 environment:
-  my_version: 2.0.15.4
+  my_version: 2.0.16.0
   my_secret:
     secure: 5qtuEW0UQ/IEO8DRi4/y3EgEBoJDM/HyYpPgzasIlm0=
 skip_branch_with_pr: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
-version: 2.0.16.{build}
+version: 2.0.15.{build}
 environment:
-  my_version: 2.0.16.0
+  my_version: 2.0.15.5
   my_secret:
     secure: 5qtuEW0UQ/IEO8DRi4/y3EgEBoJDM/HyYpPgzasIlm0=
 skip_branch_with_pr: true


### PR DESCRIPTION
Fixes #9 - Internalize Excludes are patterns and do not correlate directly to an assembly. As such they shouldn't be compared by array index with the assembly list. Causes Index out of range issues and doesn't actually exclude what we need.