### PR TITLE
Adding AllowDuplicateNamespaces option

### DIFF
--- a/ILRepack.Lib.MSBuild.Task/ILRepack.cs
+++ b/ILRepack.Lib.MSBuild.Task/ILRepack.cs
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * Copyright (c) 2004, Evain Jb (jb@evain.net)
  * Modified 2007 Marcus Griep (neoeinstein+boo@gmail.com)
  * Modified 2013 Peter Sunde (peter.sunde@gmail.com)
@@ -221,15 +221,20 @@ namespace ILRepack.Lib.MSBuild.Task
         /// </summary>
         public virtual bool Wildcards { get; set; }
 
-        #endregion
+		/// <summary>
+		/// Allows the specified type for being duplicated in input assemblies.
+		/// </summary>
+		public virtual string AllowDuplicateNamespaces { get; set; }
 
-        #region Public methods
+		#endregion
 
-        /// <summary>
-        ///     Executes ILRepack with specified options.
-        /// </summary>
-        /// <returns>Returns true if its successful.</returns>
-        public override bool Execute()
+		#region Public methods
+
+		/// <summary>
+		///     Executes ILRepack with specified options.
+		/// </summary>
+		/// <returns>Returns true if its successful.</returns>
+		public override bool Execute()
         {
             var repackOptions = new RepackOptions
             {
@@ -256,6 +261,8 @@ namespace ILRepack.Lib.MSBuild.Task
                 OutputFile = _outputFile,
                 AllowWildCards = Wildcards
             };
+
+			repackOptions.AllowedDuplicateNameSpaces.AddRange(ParseDuplicateNamspacesOption(AllowDuplicateNamespaces));
 
             Logger logger = new Logger
             {
@@ -366,6 +373,34 @@ namespace ILRepack.Lib.MSBuild.Task
         #endregion
 
         #region Private methods
+
+		/// <summary>
+		/// Parses the command line options for AllowDuplicateNamespaces.
+		/// </summary>
+		/// <param name="value">The given options.</param>
+		/// <returns>A list of all allowed namespace duplicates.</returns>
+		private static List<string> ParseDuplicateNamspacesOption(string value)
+		{
+			var list = new List<string>();
+
+			if (string.IsNullOrEmpty(value)) return list;
+
+			var split = value.Split(',');
+
+			if (split == null || split.Length == 0)
+			{
+				list.Add(value);
+			}
+			else
+			{
+				foreach (var item in split)
+				{
+					list.Add(item);
+				}
+			}
+
+			return list;
+		}
 
         /// <summary>
         /// Converts empty string to null.

--- a/ILRepack.Lib.MSBuild.Task/ILRepack.cs
+++ b/ILRepack.Lib.MSBuild.Task/ILRepack.cs
@@ -197,6 +197,11 @@ namespace ILRepack.Lib.MSBuild.Task
         public virtual bool AllowDuplicateResources { get; set; }
 
         /// <summary>
+        /// Allows the specified namespaces for being duplicated in to input assemblies.
+        /// </summary>
+        public virtual string AllowedDuplicateNamespaces { get; set; }
+
+        /// <summary>
         /// Allows assemblies with Zero PeKind (but obviously only IL will get merged).
         /// </summary>
         public virtual bool ZeroPeKind { get; set; }
@@ -221,20 +226,15 @@ namespace ILRepack.Lib.MSBuild.Task
         /// </summary>
         public virtual bool Wildcards { get; set; }
 
-		/// <summary>
-		/// Allows the specified type for being duplicated in input assemblies.
-		/// </summary>
-		public virtual string AllowDuplicateNamespaces { get; set; }
+        #endregion
 
-		#endregion
+        #region Public methods
 
-		#region Public methods
-
-		/// <summary>
-		///     Executes ILRepack with specified options.
-		/// </summary>
-		/// <returns>Returns true if its successful.</returns>
-		public override bool Execute()
+        /// <summary>
+        ///     Executes ILRepack with specified options.
+        /// </summary>
+        /// <returns>Returns true if its successful.</returns>
+        public override bool Execute()
         {
             var repackOptions = new RepackOptions
             {
@@ -262,7 +262,7 @@ namespace ILRepack.Lib.MSBuild.Task
                 AllowWildCards = Wildcards
             };
 
-			repackOptions.AllowedDuplicateNameSpaces.AddRange(ParseDuplicateNamspacesOption(AllowDuplicateNamespaces));
+            repackOptions.AllowedDuplicateNameSpaces.AddRange(ParseDuplicateNamespacesOption(AllowedDuplicateNamespaces));
 
             Logger logger = new Logger
             {
@@ -374,33 +374,17 @@ namespace ILRepack.Lib.MSBuild.Task
 
         #region Private methods
 
-		/// <summary>
-		/// Parses the command line options for AllowDuplicateNamespaces.
-		/// </summary>
-		/// <param name="value">The given options.</param>
-		/// <returns>A list of all allowed namespace duplicates.</returns>
-		private static List<string> ParseDuplicateNamspacesOption(string value)
-		{
-			var list = new List<string>();
+        /// <summary>
+        /// Parses the command line options for AllowedDuplicateNameSpaces.
+        /// </summary>
+        /// <param name="value">The given options.</param>
+        /// <returns>A collection of all allowed namespace duplicates.</returns>
+        private static IEnumerable<string> ParseDuplicateNamespacesOption(string value)
+        {
+            if (string.IsNullOrEmpty(value)) return new string[0];
 
-			if (string.IsNullOrEmpty(value)) return list;
-
-			var split = value.Split(',');
-
-			if (split == null || split.Length == 0)
-			{
-				list.Add(value);
-			}
-			else
-			{
-				foreach (var item in split)
-				{
-					list.Add(item);
-				}
-			}
-
-			return list;
-		}
+            return value.Split(',');
+        }
 
         /// <summary>
         /// Converts empty string to null.

--- a/README.md
+++ b/README.md
@@ -288,4 +288,12 @@ If you are using default targets file then you may notice that it clears Output 
             Allows (and resolves) file wildcards (e.g. `*`.dll) in input assemblies.
         </td>
     </tr>
+    <tr>
+        <td>
+            AllowDuplicateNamespaces
+        </td>
+        <td>
+            Allows the specified namespaces for being duplicated in input assemblies. Multiple namespaces are delimited by ",".
+        </td>
+    </tr>
 </table>

--- a/README.md
+++ b/README.md
@@ -256,6 +256,14 @@ If you are using default targets file then you may notice that it clears Output 
             Allows to duplicate resources in output assembly.
         </td>
     </tr>
+    <tr>
+        <td>
+            AllowedDuplicateNamespaces
+        </td>
+        <td>
+            Allows the specified namespaces for being duplicated in to input assemblies. Multiple namespaces are delimited by ",".
+        </td>
+    </tr>
 	<tr>
         <td>
             ZeroPeKind
@@ -286,14 +294,6 @@ If you are using default targets file then you may notice that it clears Output 
         </td>
         <td>
             Allows (and resolves) file wildcards (e.g. `*`.dll) in input assemblies.
-        </td>
-    </tr>
-    <tr>
-        <td>
-            AllowDuplicateNamespaces
-        </td>
-        <td>
-            Allows the specified namespaces for being duplicated in input assemblies. Multiple namespaces are delimited by ",".
         </td>
     </tr>
 </table>


### PR DESCRIPTION
When merging files with references to the same assemblies they contain the same types, namespaces or attributes. The default behaviour seems to rename these duplicates.

This adds the option to add one or more namespaces to a list of allowed duplicates.

I never worked with MSBuild tasks so i am not sure if i edited everything needed to get the option recognized. Im up for comments.