### PR TITLE
A key container is adressed by a logical name, not a path.

### DIFF
--- a/ILRepack.Lib.MSBuild.Task/ILRepack.cs
+++ b/ILRepack.Lib.MSBuild.Task/ILRepack.cs
@@ -72,7 +72,7 @@ namespace ILRepack.Lib.MSBuild.Task
         public virtual string KeyContainer
         {
             get => _keyContainer;
-            set => _keyContainer = BuildPath(ConvertEmptyToNull(value));
+            set => _keyContainer = value;
         }
 
         /// <summary>
@@ -166,7 +166,8 @@ namespace ILRepack.Lib.MSBuild.Task
         public virtual bool RenameInternalized { get; set; }
 
         /// <summary>
-        /// List of assemblies that should not be internalized.
+        /// List of  contains namespaces to exclude. One item should contain a regex 
+        /// to compare against FullName of types NOT to internalize that should not be internalized.
         /// </summary>
         public virtual ITaskItem[] InternalizeExclude { get; set; }
 

--- a/ILRepack.Lib.MSBuild.Task/ILRepack.cs
+++ b/ILRepack.Lib.MSBuild.Task/ILRepack.cs
@@ -166,8 +166,8 @@ namespace ILRepack.Lib.MSBuild.Task
         public virtual bool RenameInternalized { get; set; }
 
         /// <summary>
-        /// List of  contains namespaces to exclude. One item should contain a regex 
-        /// to compare against FullName of types NOT to internalize that should not be internalized.
+        /// If Internalize is set to true, any which match these regular expressions will not be internalized. 
+        /// If internalize is false, then this property is ignored.
         /// </summary>
         public virtual ITaskItem[] InternalizeExclude { get; set; }
 


### PR DESCRIPTION
We are using a key container in order to sign our assemblies. While debugging the taske I noticed the bug where the workdir path will be prefixed. A key container is addressed by a locigal name.

Kind regards,

Carsten