### PR TITLE
Populate RepackDropAttributes from specified RepackDropAttribute.

### DIFF
--- a/ILRepack.Lib.MSBuild.Task/ILRepack.cs
+++ b/ILRepack.Lib.MSBuild.Task/ILRepack.cs
@@ -213,7 +213,7 @@ namespace ILRepack.Lib.MSBuild.Task
         /// <summary>
         ///     Name of an attribute (optional). Members in input assemblies marked with this attribute will be dropped during merging.
         /// </summary>
-        public string RepackDropAttribute { get; set; }
+        public virtual string RepackDropAttribute { get; set; }
 
         #endregion
 
@@ -329,6 +329,11 @@ namespace ILRepack.Lib.MSBuild.Task
                 if (InternalizeAssembly != null && InternalizeAssembly.Any())
                 {
                     repackOptions.InternalizeAssemblies = InternalizeAssembly.Select(i => StripExtension(i.ItemSpec)).ToArray();
+                }
+
+                if (!string.IsNullOrWhiteSpace(repackOptions.RepackDropAttribute))
+                {
+                    repackOptions.RepackDropAttributes.UnionWith(RepackDropAttribute.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries));
                 }
 
                 // Path that will be used when searching for assemblies to merge.


### PR DESCRIPTION
Fixes ravibpatel/ILRepack.Lib.MSBuild.Task#55. Populates the `RepackDropAttributes` HashSet, parsed from a colon (`;`) delimited list of attributes to be dropped. This implementation aligns closely with the implementation in `RepackOptions` in the main IL Repack repo and how it's parsed from the command line (see https://github.com/gluck/il-repack/blob/master/ILRepack/RepackOptions.cs#L288). `RepackDropAttribute` is not used independently in the current version of IL Repack.