### PR TITLE
Update documentation with new /illink parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ You can turn this functionality off by setting ClearOutputDirectory to False as 
 | KeyFile                        | Specifies a key file to sign the output assembly.                                                                                                          |
 | LibraryPath                    | List of paths to use as "include directories" when attempting to merge assemblies.                                                                         |
 | LogFile                        | Specifies a log file to output log information.                                                                                                            |
+| MergeIlLinkerFiles             | Merge IL Linker file XML resources from Microsoft assemblies (optional). Same-named XML resources ('ILLink.*.xml') will be combined during merging.        |
 | NoRepackRes                    | Does not add the embedded resource 'ILRepack.List' with all merged assembly names.                                                                         |
 | OutputFile                     | Output name for the merged assembly.                                                                                                                       |
 | Parallel                       | Use as many CPUs as possible to merge the assemblies.                                                                                                      |


### PR DESCRIPTION
Adding support for the new /illink switch, introduced [here](https://github.com/gluck/il-repack/commit/986c1dbc761cce86caf1d8d79adfbcb47b5e0e06#diff-3ee934cbb99395b6bc4f805ef4e686e6d80b0b8e1c27d552ed9590eae4f4bb6fR256).