### PR TITLE
Disable/Enable the default Target.

### DIFF
--- a/ILRepack.Lib.MSBuild.Task/ILRepack.Lib.MSBuild.Task.csproj
+++ b/ILRepack.Lib.MSBuild.Task/ILRepack.Lib.MSBuild.Task.csproj
@@ -18,6 +18,7 @@
         <None Include="build\ILRepack.Lib.MSBuild.Task.nuspec"/>
         <None Include="ILRepack.Config.props"/>
         <None Include="ILRepack.Lib.MSBuild.Task.snk"/>
+        <None Include="ILRepack.Lib.MSBuild.Task.props" CopyToOutputDirectory="PreserveNewest"/>
         <None Include="ILRepack.Lib.MSBuild.Task.targets" CopyToOutputDirectory="PreserveNewest"/>
     </ItemGroup>
 

--- a/ILRepack.Lib.MSBuild.Task/ILRepack.Lib.MSBuild.Task.props
+++ b/ILRepack.Lib.MSBuild.Task/ILRepack.Lib.MSBuild.Task.props
@@ -1,0 +1,3 @@
+﻿<Project>
+    <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)ILRepack.Lib.MSBuild.Task.dll" TaskName="ILRepack"/>
+</Project>

--- a/ILRepack.Lib.MSBuild.Task/ILRepack.Lib.MSBuild.Task.targets
+++ b/ILRepack.Lib.MSBuild.Task/ILRepack.Lib.MSBuild.Task.targets
@@ -3,10 +3,14 @@
 
     <PropertyGroup>
         <ILRepackTargetsFile Condition="$(ILRepackTargetsFile) == ''">$(ProjectDir)ILRepack.targets</ILRepackTargetsFile>
+        <ILRepackEnabled Condition="'$(ILRepackEnabled)' == '' and $(Configuration.Contains('Release'))">true</ILRepackEnabled>
+        <ILRepackEnabled Condition="'$(ILRepackEnabled)' == ''">false</ILRepackEnabled>
+        <ILRepackEnabled Condition="Exists('$(ILRepackTargetsFile)')">false</ILRepackEnabled>
+        <ClearOutputDirectory Condition="'$(ClearOutputDirectory)' == ''">true</ClearOutputDirectory>
     </PropertyGroup>
 
     <Import Project="$(ILRepackTargetsFile)" Condition="Exists('$(ILRepackTargetsFile)')"/>
-    <Target Name="ILRepack" AfterTargets="Build" Condition="$(Configuration.Contains('Release')) and !Exists('$(ILRepackTargetsFile)')">
+    <Target Name="ILRepack" AfterTargets="Build" Condition="$(ILRepackEnabled)">
         <ItemGroup>
             <InputAssemblies Include="$(OutputPath)$(TargetName)$(TargetExt)"/>
             <InputAssemblies Include="$(OutputPath)*.dll" Exclude="$(OutputPath)$(TargetName)$(TargetExt)"/>
@@ -25,7 +29,7 @@
     <Target
             AfterTargets="ILRepack"
             Name="CleanReferenceCopyLocalPaths"
-            Condition="$(Configuration.Contains('Release')) and !Exists('$(ILRepackTargetsFile)') and '$(ClearOutputDirectory)' != 'False'">
+            Condition="$(ILRepackEnabled) and $(ClearOutputDirectory)">
         <Delete Files="@(ReferenceCopyLocalPaths->'$(OutDir)%(DestinationSubDirectory)%(Filename)%(Extension)')"/>
         <ItemGroup>
             <Directories Include="$([System.IO.Directory]::GetDirectories('$(OutDir)%(DestinationSubDirectory)', '*', System.IO.SearchOption.AllDirectories))"/>

--- a/ILRepack.Lib.MSBuild.Task/ILRepack.Lib.MSBuild.Task.targets
+++ b/ILRepack.Lib.MSBuild.Task/ILRepack.Lib.MSBuild.Task.targets
@@ -5,7 +5,6 @@
         <ILRepackTargetsFile Condition="$(ILRepackTargetsFile) == ''">$(ProjectDir)ILRepack.targets</ILRepackTargetsFile>
     </PropertyGroup>
 
-    <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)ILRepack.Lib.MSBuild.Task.dll" TaskName="ILRepack"/>
     <Import Project="$(ILRepackTargetsFile)" Condition="Exists('$(ILRepackTargetsFile)')"/>
     <Target Name="ILRepack" AfterTargets="Build" Condition="$(Configuration.Contains('Release')) and !Exists('$(ILRepackTargetsFile)')">
         <ItemGroup>

--- a/ILRepack.Lib.MSBuild.Task/ILRepack.cs
+++ b/ILRepack.Lib.MSBuild.Task/ILRepack.cs
@@ -52,6 +52,11 @@ namespace ILRepack.Lib.MSBuild.Task
         }
 
         /// <summary>
+        ///     Specifies whether to log task messages.
+        /// </summary>
+        public virtual bool LogTaskMessage { get; set; } = true;
+
+        /// <summary>
         ///     Merges types with identical names into one.
         /// </summary>
         public virtual bool Union { get; set; }
@@ -300,7 +305,7 @@ namespace ILRepack.Lib.MSBuild.Task
                         throw new Exception($"Unable to resolve assembly '{assemblies[i]}'");
                     }
 
-                    Log.LogMessage(MessageImportance.High, "Added assembly '{0}'", assemblies[i]);
+                    LogMessage("Added assembly '{0}'", assemblies[i]);
                 }
 
                 // List of regex to compare against FullName of types NOT to internalize
@@ -318,7 +323,7 @@ namespace ILRepack.Lib.MSBuild.Task
                                     $"Invalid internalize exclude pattern at item index {i}. Pattern cannot be blank.");
                             }
 
-                            Log.LogMessage(MessageImportance.High,
+                            LogMessage(
                                 "Excluding namespaces/types matching pattern '{0}' from being internalized",
                                 internalizeExclude[i]);
                         }
@@ -348,7 +353,7 @@ namespace ILRepack.Lib.MSBuild.Task
                 repackOptions.SearchDirectories = searchPath.ToArray();
 
                 // Attempt to merge assemblies.
-                Log.LogMessage(MessageImportance.High, "Merging {0} assembl{1} to '{2}'",
+                LogMessage("Merging {0} assembl{1} to '{2}'",
                     InputAssemblies.Length, InputAssemblies.Length != 1 ? "ies" : "y", _outputFile);
 
                 // Measure performance
@@ -365,7 +370,7 @@ namespace ILRepack.Lib.MSBuild.Task
 
                 stopWatch.Stop();
 
-                Log.LogMessage(MessageImportance.High, "Merge succeeded in {0} s", stopWatch.Elapsed.TotalSeconds);
+                LogMessage("Merge succeeded in {0} s", stopWatch.Elapsed.TotalSeconds);
                 logger.Close();
 
                 return true;
@@ -379,9 +384,16 @@ namespace ILRepack.Lib.MSBuild.Task
             }
         }
 
-        #endregion
-
-        #region Private methods
+        /// <summary>
+        /// Logs a message with the specified format and arguments.
+        /// </summary>
+        /// <param name="message">The message format.</param>
+        /// <param name="messageArgs">The arguments for the message format.</param>
+        private void LogMessage(string message, params object[] messageArgs)
+        {
+            var importance = LogTaskMessage ? MessageImportance.High : MessageImportance.Low;
+            Log.LogMessage(importance, message, messageArgs);
+        }
 
         /// <summary>
         ///     Parses the command line options for AllowedDuplicateNameSpaces.

--- a/ILRepack.Lib.MSBuild.Task/ILRepack.cs
+++ b/ILRepack.Lib.MSBuild.Task/ILRepack.cs
@@ -19,6 +19,7 @@ namespace ILRepack.Lib.MSBuild.Task
         private string _keyContainer;
         private ILRepacking.ILRepack.Kind _targetKind;
         private string _excludeFileTmpPath;
+        private MessageImportance _messageImportance = MessageImportance.High; 
 
         #endregion
 
@@ -52,9 +53,12 @@ namespace ILRepack.Lib.MSBuild.Task
         }
 
         /// <summary>
-        ///     Specifies the log task messages importance (High/true by default).
+        ///     Specifies the log task messages importance (High by default).
         /// </summary>
-        public virtual bool LogTaskMessageImportance { get; set; } = true;
+        public virtual string LogImportance { 
+            get => _messageImportance.ToString();
+            set => Enum.TryParse(value, true, out _messageImportance); 
+        }
 
         /// <summary>
         ///     Merges types with identical names into one.
@@ -391,9 +395,10 @@ namespace ILRepack.Lib.MSBuild.Task
         /// <param name="messageArgs">The arguments for the message format.</param>
         private void LogMessage(string message, params object[] messageArgs)
         {
-            var importance = LogTaskMessageImportance ? MessageImportance.High : MessageImportance.Low;
-            Log.LogMessage(importance, message, messageArgs);
+            Log.LogMessage(_messageImportance, message, messageArgs);
         }
+
+
 
         /// <summary>
         ///     Parses the command line options for AllowedDuplicateNameSpaces.

--- a/ILRepack.Lib.MSBuild.Task/ILRepack.cs
+++ b/ILRepack.Lib.MSBuild.Task/ILRepack.cs
@@ -52,9 +52,9 @@ namespace ILRepack.Lib.MSBuild.Task
         }
 
         /// <summary>
-        ///     Specifies whether to log task messages.
+        ///     Specifies the log task messages importance (High/true by default).
         /// </summary>
-        public virtual bool LogTaskMessage { get; set; } = true;
+        public virtual bool LogTaskMessageImportance { get; set; } = true;
 
         /// <summary>
         ///     Merges types with identical names into one.
@@ -391,7 +391,7 @@ namespace ILRepack.Lib.MSBuild.Task
         /// <param name="messageArgs">The arguments for the message format.</param>
         private void LogMessage(string message, params object[] messageArgs)
         {
-            var importance = LogTaskMessage ? MessageImportance.High : MessageImportance.Low;
+            var importance = LogTaskMessageImportance ? MessageImportance.High : MessageImportance.Low;
             Log.LogMessage(importance, message, messageArgs);
         }
 

--- a/ILRepack.Lib.MSBuild.Task/ILRepack.cs
+++ b/ILRepack.Lib.MSBuild.Task/ILRepack.cs
@@ -398,8 +398,6 @@ namespace ILRepack.Lib.MSBuild.Task
             Log.LogMessage(_messageImportance, message, messageArgs);
         }
 
-
-
         /// <summary>
         ///     Parses the command line options for AllowedDuplicateNameSpaces.
         /// </summary>

--- a/ILRepack.Lib.MSBuild.Task/build/ILRepack.Lib.MSBuild.Task.nuspec
+++ b/ILRepack.Lib.MSBuild.Task/build/ILRepack.Lib.MSBuild.Task.nuspec
@@ -19,6 +19,7 @@
     </metadata>
     <files>
         <file src="ILRepack.Lib.MSBuild.Task.dll" target="build"/>
+        <file src="ILRepack.Lib.MSBuild.Task.props" target="build"/>
         <file src="ILRepack.Lib.MSBuild.Task.targets" target="build"/>
     </files>
 </package>

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ You can turn this functionality off by setting ClearOutputDirectory to False as 
 | KeyFile                        | Specifies a key file to sign the output assembly.                                                                                                          |
 | LibraryPath                    | List of paths to use as "include directories" when attempting to merge assemblies.                                                                         |
 | LogFile                        | Specifies a log file to output log information.                                                                                                            |
-| LogTaskMessageImportance       | Specifies the log message importance in the task. (`true` by default)                                                                                      | 
+| LogImportance                  | Specifies the log message importance in the task. (`high` by default, `normal` and `low` available)                                                        | 
 | MergeIlLinkerFiles             | Merge IL Linker file XML resources from Microsoft assemblies (optional). Same-named XML resources ('ILLink.*.xml') will be combined during merging.        |
 | NoRepackRes                    | Does not add the embedded resource 'ILRepack.List' with all merged assembly names.                                                                         |
 | OutputFile                     | Output name for the merged assembly.                                                                                                                       |

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ You can turn this functionality off by setting ClearOutputDirectory to False as 
 | KeyFile                        | Specifies a key file to sign the output assembly.                                                                                                          |
 | LibraryPath                    | List of paths to use as "include directories" when attempting to merge assemblies.                                                                         |
 | LogFile                        | Specifies a log file to output log information.                                                                                                            |
+| LogTaskMessageImportance       | Specifies the log message importance in the task. (`true` by default)                                                                                      | 
 | MergeIlLinkerFiles             | Merge IL Linker file XML resources from Microsoft assemblies (optional). Same-named XML resources ('ILLink.*.xml') will be combined during merging.        |
 | NoRepackRes                    | Does not add the embedded resource 'ILRepack.List' with all merged assembly names.                                                                         |
 | OutputFile                     | Output name for the merged assembly.                                                                                                                       |

--- a/README.md
+++ b/README.md
@@ -80,13 +80,22 @@ option only applies if you are using default targets file provided in NuGet pack
 <KeyFile>$(ProjectDir)ILRepack.snk</KeyFile>
 ```
 
+### Disable default ILRepack Target
+
+By default if no "ILRepack.targets" file is found a default ILRepack Target runs after build if the configuration contains "Release".
+You can disable this behavior by setting the following property to `false` or `true` to enable it.
+
+```xml
+<ILRepackEnabled>false</ILRepackEnabled>
+```
+
 ### Specify whether to clear directory after merging
 
 If you are using default targets file then you may notice that it clears Output directory after merging dependencies.
 You can turn this functionality off by setting ClearOutputDirectory to False as shown below.
 
 ```xml
-<ClearOutputDirectory>False</ClearOutputDirectory>
+<ClearOutputDirectory>false</ClearOutputDirectory>
 ```
 
 ## Task options


### PR DESCRIPTION
This PR is related to the #62 to disable the default ILRepack Target and enable to use the `ILRepack` task in the main `.csproj`.

Here so changes:
* Move the `UsingTask` to the `.props` to enable using `ILRepack` in any Target.
* `ILRepackEnabled` property to disable the default Target.
* Field `LogImportance` in the `ILRepack` Task to choose the log level.

