### PR TITLE
Added support for multi targetting in package

### DIFF
--- a/ILRepack.Lib.MSBuild.Task/build/ILRepack.Lib.MSBuild.Task.nuspec
+++ b/ILRepack.Lib.MSBuild.Task/build/ILRepack.Lib.MSBuild.Task.nuspec
@@ -19,6 +19,7 @@
     </metadata>
     <files>
         <file src="ILRepack.Lib.MSBuild.Task.dll" target="build"/>
-        <file src="ILRepack.Lib.MSBuild.Task.targets" target="build"/>
+		<file src="ILRepack.Lib.MSBuild.Task.targets" target="build"/>
+		<file src="ILRepack.Lib.MSBuild.Task.targets" target="buildCrossTargeting"/>
     </files>
 </package>


### PR DESCRIPTION
Updated the nuspec to output the targets file to buildCrossTargeting folder.

It should be enough based on the testing I was able to do here (Manually finding (locally and on GHA) and loading the targets file:
https://github.com/sundews/Sundew.Xaml.Optimizer.BuildTask/blob/7eb5c7c3fc54473bf88e3c51c603275183684792/Source/Sundew.Xaml.Optimizer.BuildTask/Sundew.Xaml.Optimizer.BuildTask.csproj#L3-L4

PR:
https://github.com/ravibpatel/ILRepack.Lib.MSBuild.Task/pull/75

If you can provide a prerelease build I can give a quick test