### PR TITLE
Output the MSBuild Task in buildCrossTargetting as well

### DIFF
--- a/ILRepack.Lib.MSBuild.Task/build/ILRepack.Lib.MSBuild.Task.nuspec
+++ b/ILRepack.Lib.MSBuild.Task/build/ILRepack.Lib.MSBuild.Task.nuspec
@@ -19,6 +19,7 @@
     </metadata>
     <files>
         <file src="ILRepack.Lib.MSBuild.Task.dll" target="build"/>
+        <file src="ILRepack.Lib.MSBuild.Task.dll" target="buildCrossTargeting"/>
 		<file src="ILRepack.Lib.MSBuild.Task.targets" target="build"/>
 		<file src="ILRepack.Lib.MSBuild.Task.targets" target="buildCrossTargeting"/>
     </files>


### PR DESCRIPTION
With version 2.0.44 it was not able to find the `ILRepack.Lib.MSBuild.Task.dll` due to the introduction of multi targeting support (Issue: #73 - PR #75).

The problem is that the `ILRepack.Lib.MSBuild.Task.targets` file assumes that the `ILRepack.Lib.MSBuild.Task.dll` to sit next to it:

```xml
<UsingTask AssemblyFile="$(MSBuildThisFileDirectory)ILRepack.Lib.MSBuild.Task.dll" TaskName="ILRepack"/>
```

But in the `.nuspec` the DLL was not outputted to the `buildCrossTargeting` folder as well:

<img width="604" height="208" alt="image" src="https://github.com/user-attachments/assets/6dc5037b-1e89-4f36-bcfb-ff531aaab18d" />

