### PR TITLE
Simplify multi-targeting files

### DIFF
--- a/ILRepack.Lib.MSBuild.Task/ILRepack.Lib.MSBuild.Task.csproj
+++ b/ILRepack.Lib.MSBuild.Task/ILRepack.Lib.MSBuild.Task.csproj
@@ -19,6 +19,7 @@
         <None Include="ILRepack.Config.props"/>
         <None Include="ILRepack.Lib.MSBuild.Task.snk"/>
         <None Include="ILRepack.Lib.MSBuild.Task.targets" CopyToOutputDirectory="PreserveNewest"/>
+        <None Include="ILRepack.Lib.MSBuild.Task.multitarget.targets" CopyToOutputDirectory="PreserveNewest"/>
     </ItemGroup>
 
     <Target Name="Repack" AfterTargets="Build">

--- a/ILRepack.Lib.MSBuild.Task/ILRepack.Lib.MSBuild.Task.multitarget.targets
+++ b/ILRepack.Lib.MSBuild.Task/ILRepack.Lib.MSBuild.Task.multitarget.targets
@@ -1,0 +1,3 @@
+﻿<Project>
+    <Import Project="$(MSBuildThisFileDirectory)..\build\ILRepack.Lib.MSBuild.Task.targets" />
+</Project>

--- a/ILRepack.Lib.MSBuild.Task/build/ILRepack.Lib.MSBuild.Task.nuspec
+++ b/ILRepack.Lib.MSBuild.Task/build/ILRepack.Lib.MSBuild.Task.nuspec
@@ -19,8 +19,7 @@
     </metadata>
     <files>
         <file src="ILRepack.Lib.MSBuild.Task.dll" target="build"/>
-        <file src="ILRepack.Lib.MSBuild.Task.dll" target="buildCrossTargeting"/>
-		<file src="ILRepack.Lib.MSBuild.Task.targets" target="build"/>
-		<file src="ILRepack.Lib.MSBuild.Task.targets" target="buildCrossTargeting"/>
+        <file src="ILRepack.Lib.MSBuild.Task.targets" target="build"/>
+        <file src="ILRepack.Lib.MSBuild.Task.multitarget.targets" target="buildMultiTargeting\ILRepack.Lib.MSBuild.Task.targets"/>
     </files>
 </package>


### PR DESCRIPTION
Simplifies the multi-targeting implementation by removing the duplicate DLL and targets file and instead just redirecting it.

Also switches to the documented directory name as mentioned in #75.

Closes: #73 